### PR TITLE
WIP Improve map performance by changing listeners

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,14 +68,14 @@ jobs:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Set Up Gdal
-        run: |
-          sudo apt-get update
-          sudo apt-get install gdal-bin
-          echo ogrinfo --version
+      # - name: Set Up Gdal
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install gdal-bin
+      #     echo ogrinfo --version
 
-      - name: setup-chromedriver
-        uses: nanasess/setup-chromedriver@v2.2.0
+      # - name: setup-chromedriver
+      #   uses: nanasess/setup-chromedriver@v2.2.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,10 @@ jobs:
       matrix:
         python-version: [ "3.10" ]
     # You must use a Linux environment when using service containers or container jobs
+    # instead of ubunut we use ubuntu + gdal to reduce build/install time
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/osgeo/gdal:ubuntu-full-latest
     timeout-minutes: 10
     # Service containers to run with `runner-job`
     services:
@@ -62,18 +65,24 @@ jobs:
           - 5432:5432
 
     steps:
-      - name: Create postgis extensions
+      - name: Install CI dependencies
         run: |
-          PGPASSWORD=postgres psql -h localhost -d DbName -U postgres -c 'create extension postgis_raster;'
+          apt-get update
+          apt-get install -y --no-install-recommends \
+          git \
+          postgresql-client \
+          build-essential \
+          libpq-dev
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
         uses: actions/checkout@v4
-      # - name: Set Up Gdal
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install gdal-bin
-      #     echo ogrinfo --version
-
+      - name: Check GDAL
+        run: gdalinfo --version
+      # when using a container for django, database is not on localhost but available through service
+      # -h localhost -> -h postgres
+      - name: Create postgis extensions (needs PostgreSQL client)
+        run: |
+          PGPASSWORD=postgres psql -h postgres -d DbName -U postgres -c 'create extension postgis_raster;'
       # - name: setup-chromedriver
       #   uses: nanasess/setup-chromedriver@v2.2.0
       - name: Set up Python ${{ matrix.python-version }}
@@ -95,8 +104,8 @@ jobs:
           DJANGO_SECRET_KEY: ${{ secrets.SECRET_KEY }}
           DJANGO_ADMIN_PASSWORD: ${{ secrets.SECRET_KEY }}
           DJANGO_DEBUG: True
-          # Replace with your own database info
-          DATABASE_URL: postgis://postgres:postgres@localhost/DbName
+          # Replace with your own database info @localhost -> @postgres
+          DATABASE_URL: postgis://postgres:postgres@postgres/DbName
           CELERY_TASK_ALWAYS_EAGER: True
           CELERY_BROKER_URL: pyamqp://guest@localhost//
           TILING_SERVICE_TOKEN: ${{ secrets.TILING_SERVICE_TOKEN }}

--- a/core/urls.py
+++ b/core/urls.py
@@ -87,8 +87,8 @@ urlpatterns = [
         name="szenarienvergleich",
     ),
     path(
-        "ergebnisse/<uuid:project_internal_id>/",
-        views.project_overview_view,
+        "ergebnisse/<uuid:scenario_internal_id>/",
+        views.scenario_results,
         name="ergebnisse",
     ),
 ]

--- a/ports/templates/ports/partials/flaechen_tab_panel.html
+++ b/ports/templates/ports/partials/flaechen_tab_panel.html
@@ -90,7 +90,9 @@
       hx-get="{% url 'ports:geometries' scenario.internal_id %}"
       hx-trigger="load"
       hx-swap='innerHTML'
-      hx-on::after-request=" htmx.trigger('body' ,'map-redraw');"
+      hx-on::after-settle=" htmx.trigger('body' ,'map-redraw-sync');
+      myMap.fitToElements();
+      "
     >
     </div>
 

--- a/ports/templates/ports/partials/flaechen_tab_panel.html
+++ b/ports/templates/ports/partials/flaechen_tab_panel.html
@@ -84,9 +84,8 @@
     {% comment %}
     These elements represent the state of the map elements.
     Hidden by default, but can be inspected for debugging purposes
+    The geometries are lazy loaded for fast first draw of page. The map is redrawn afterwards
     {% endcomment %}
-
-
     <div id="geom_forms_container" class="hidden h-30 border-2 m-2 overflow-y-scroll overflow-clip"
       hx-get="{% url 'ports:geometries' scenario.internal_id %}"
       hx-trigger="load"

--- a/ports/templates/ports/partials/flaechen_tab_panel.html
+++ b/ports/templates/ports/partials/flaechen_tab_panel.html
@@ -85,16 +85,15 @@
     These elements represent the state of the map elements.
     Hidden by default, but can be inspected for debugging purposes
     {% endcomment %}
-    <div id="geom_forms_container" class="hidden h-30 border-2 m-2 overflow-y-scroll overflow-clip">
-      {% for geom_form in area_forms %}
-          <div id="geom_form_container_{{geom_form.instance.internal_id}}"
-              hx-swap-oob='true'
-          >
-          {% include 'ports/partials/map_element.html' with form=geom_form %}
-          </div>
-      {% endfor %}
-    </div>
 
+
+    <div id="geom_forms_container" class="hidden h-30 border-2 m-2 overflow-y-scroll overflow-clip"
+      hx-get="{% url 'ports:geometries' scenario.internal_id %}"
+      hx-trigger="load"
+      hx-swap='innerHTML'
+      hx-on::after-request=" htmx.trigger('body' ,'map-redraw');"
+    >
+    </div>
 
     {% partialdef add-gebaeudeflaeche-button inline %}
       <button type='button'

--- a/ports/templates/ports/partials/geometries.html
+++ b/ports/templates/ports/partials/geometries.html
@@ -1,0 +1,6 @@
+{% for geom_form in area_forms %}
+<div id="geom_form_container_{{geom_form.instance.internal_id}}"
+>
+    {% include 'ports/partials/map_element.html' with form=geom_form %}
+</div>
+{% endfor %}

--- a/ports/urls.py
+++ b/ports/urls.py
@@ -46,6 +46,11 @@ urlpatterns = [
         name="changes",
     ),
     path(
+        "geometries/<uuid:scenario_internal_id>/",
+        views.geometries,
+        name="geometries",
+    ),
+    path(
         "details/<uuid:scenario_internal_id>/<str:model>/",
         views.DetailsView.as_view(created=False),
         name="details",

--- a/ports/views.py
+++ b/ports/views.py
@@ -189,15 +189,25 @@ def changes_count(request, scenario_internal_id: UUID):
 
 
 def geometries(request, scenario_internal_id: UUID):
-    # TODO: Harden authentification
     scenario: Scenario = get_object_or_404(Scenario, internal_id=scenario_internal_id)
     if not get_authentification(scenario, request.user, "read"):
         return HttpResponseForbidden("No access")
     context = {}
     all_areas = list(Area.objects.filter(scenario=scenario).prefetch_related("generator_set"))
+
+    base_qs = Area.objects.filter(scenario=scenario)
+    allowed_details_ids = set(
+        get_objects_for_user(request.user, "details", base_qs).values_list("id", flat=True)
+    )
+    managed_area_ids = set(base_qs.filter(manager=request.user).values_list("id", flat=True))
+    allowed_details_ids_union = allowed_details_ids.union(managed_area_ids)
+
     area_forms = []
     for a in all_areas:
-        area_forms.append(AreaItemFormFactory()(instance=a))
+        form = AreaItemFormFactory()(instance=a)
+        if a.id in allowed_details_ids_union:
+            a.has_authorization = True
+        area_forms.append(form)
     context["area_forms"] = area_forms
     context["scenario"] = scenario
     return render(request, "ports/partials/geometries.html", context)

--- a/ports/views.py
+++ b/ports/views.py
@@ -188,6 +188,21 @@ def changes_count(request, scenario_internal_id: UUID):
     return render(request, "ports/partials/changes_count.html", context)
 
 
+def geometries(request, scenario_internal_id: UUID):
+    # TODO: Harden authentification
+    scenario: Scenario = get_object_or_404(Scenario, internal_id=scenario_internal_id)
+    if not get_authentification(scenario, request.user, "read"):
+        return HttpResponseForbidden("No access")
+    context = {}
+    all_areas = list(Area.objects.filter(scenario=scenario).prefetch_related("generator_set"))
+    area_forms = []
+    for a in all_areas:
+        area_forms.append(AreaItemFormFactory()(instance=a))
+    context["area_forms"] = area_forms
+    context["scenario"] = scenario
+    return render(request, "ports/partials/geometries.html", context)
+
+
 def changes(request, scenario_internal_id: UUID):
     """View for changelog
 

--- a/static/css/output.css
+++ b/static/css/output.css
@@ -436,9 +436,6 @@
   .-mt-2 {
     margin-top: calc(var(--spacing) * -2);
   }
-  .mt-0 {
-    margin-top: calc(var(--spacing) * 0);
-  }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
@@ -901,9 +898,6 @@
   .flex-\[1_0_0\] {
     flex: 1 0 0;
   }
-  .flex-shrink {
-    flex-shrink: 1;
-  }
   .flex-shrink-0 {
     flex-shrink: 0;
   }
@@ -922,10 +916,6 @@
   }
   .translate-x-full {
     --tw-translate-x: 100%;
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -1031,9 +1021,6 @@
   .justify-end {
     justify-content: flex-end;
   }
-  .gap-0 {
-    gap: calc(var(--spacing) * 0);
-  }
   .gap-0\.5 {
     gap: calc(var(--spacing) * 0.5);
   }
@@ -1110,9 +1097,6 @@
       margin-inline-start: calc(calc(var(--spacing) * 6) * var(--tw-space-x-reverse));
       margin-inline-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-x-reverse)));
     }
-  }
-  .gap-y-1 {
-    row-gap: calc(var(--spacing) * 1);
   }
   .gap-y-1\.5 {
     row-gap: calc(var(--spacing) * 1.5);
@@ -1409,9 +1393,6 @@
   .bg-amber-100 {
     background-color: var(--color-amber-100);
   }
-  .bg-amber-200 {
-    background-color: var(--color-amber-200);
-  }
   .bg-amber-300 {
     background-color: var(--color-amber-300);
   }
@@ -1444,9 +1425,6 @@
   }
   .bg-cyan-500 {
     background-color: var(--color-cyan-500);
-  }
-  .bg-cyan-600 {
-    background-color: var(--color-cyan-600);
   }
   .bg-cyan-600\/50 {
     background-color: color-mix(in srgb, oklch(60.9% 0.126 221.723) 50%, transparent);
@@ -1625,9 +1603,6 @@
   .px-\[24px\] {
     padding-inline: 24px;
   }
-  .py-0 {
-    padding-block: calc(var(--spacing) * 0);
-  }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
   }
@@ -1684,9 +1659,6 @@
   }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
-  }
-  .pt-1 {
-    padding-top: calc(var(--spacing) * 1);
   }
   .pt-1\.5 {
     padding-top: calc(var(--spacing) * 1.5);
@@ -1963,9 +1935,6 @@
   .text-nowrap {
     text-wrap: nowrap;
   }
-  .text-wrap {
-    text-wrap: wrap;
-  }
   .text-ellipsis {
     text-overflow: ellipsis;
   }
@@ -2010,9 +1979,6 @@
   }
   .text-amber-800 {
     color: var(--color-amber-800);
-  }
-  .text-black {
-    color: var(--color-black);
   }
   .text-blue-500 {
     color: var(--color-blue-500);
@@ -2131,14 +2097,8 @@
   .uppercase {
     text-transform: uppercase;
   }
-  .italic {
-    font-style: italic;
-  }
   .not-italic {
     font-style: normal;
-  }
-  .underline {
-    text-decoration-line: underline;
   }
   .underline-offset-4 {
     text-underline-offset: 4px;

--- a/static/js/create_map.js
+++ b/static/js/create_map.js
@@ -34,6 +34,7 @@ class MyMap {
     const debounced_draw = debounce(this.drawElements.bind(this), 10);
     document.addEventListener('alpine:initialized', () => this.drawElements());
     document.addEventListener('map-redraw', () => debounced_draw());
+    document.addEventListener('map-redraw-sync', () => this.drawElements());
     document.addEventListener('geom-changed', () => debounced_draw());
   }
 
@@ -470,7 +471,12 @@ class MyMap {
             if (e.originalEvent.shiftKey) {
               event = new CustomEvent('map-layer-shift-clicked', { detail: { value: layer.key }, bubbles: true });
             } else {
-              event = new CustomEvent('map-layer-clicked', { detail: { value: layer.key }, bubbles: true });
+              // fire the select-instance-id event. the list item can listen for it and toggle its state accordingly
+              event = new CustomEvent('select-instance-' + layer.key, { detail: { value: layer.key }, bubbles: true });
+              // maybe fire different event later on or introduce middlestep
+              // event = new CustomEvent('map-layer-clicked', { detail: { value: layer.key }, bubbles: true });
+
+
             }
             document.dispatchEvent(event);
           }

--- a/static/js/map-events-interface.js
+++ b/static/js/map-events-interface.js
@@ -44,26 +44,27 @@ document.addEventListener('keyup', (event) => {
 
 
 mapdiv = document.getElementById('mapElement');
-mapdiv.addEventListener('map-elements-edited', (event) => {
-  console.log('map-elements-edited')
-  targets = [];
-  event.detail.layers.forEach((layer) => {
-    target = document.getElementById(layer.id);
-    target.value = JSON.stringify(layer.toGeoJSON().geometry);
-    targets.push(target);
+if (mapdiv) {
+  mapdiv.addEventListener('map-elements-edited', (event) => {
+    console.log('map-elements-edited')
+    targets = [];
+    event.detail.layers.forEach((layer) => {
+      target = document.getElementById(layer.id);
+      target.value = JSON.stringify(layer.toGeoJSON().geometry);
+      targets.push(target);
+    });
+    // Targets may trigger map redraw. this can effect unstored saves of the editiable layer
+    // Therefor we trigger the change events only after all inputs have been transfered to the inputs
+    targets.forEach((target) => target.dispatchEvent(new Event('change', { bubbles: true })));
+  })
+
+  mapdiv.addEventListener('some-map-element-created', (event) => {
+    // Add the reference to the created Polygon
+    if (createPolygonKey != null) {
+      event.detail.key = createPolygonKey
+      geojson = JSON.stringify(event.detail.layer.toGeoJSON().geometry);
+      document.dispatchEvent(new CustomEvent('map-element-created', { detail: { key: createPolygonKey, geojson: geojson }, bubbles: true }))
+    }
+    event.stopPropagation()
   });
-  // Targets may trigger map redraw. this can effect unstored saves of the editiable layer
-  // Therefor we trigger the change events only after all inputs have been transfered to the inputs
-  targets.forEach((target) => target.dispatchEvent(new Event('change', { bubbles: true })));
-
-})
-
-mapdiv.addEventListener('some-map-element-created', (event) => {
-  // Add the reference to the created Polygon
-  if (createPolygonKey != null) {
-    event.detail.key = createPolygonKey
-    geojson = JSON.stringify(event.detail.layer.toGeoJSON().geometry);
-    document.dispatchEvent(new CustomEvent('map-element-created', { detail: { key: createPolygonKey, geojson: geojson }, bubbles: true }))
-  }
-  event.stopPropagation()
-});
+}

--- a/static/js/map-interface-enetra.js
+++ b/static/js/map-interface-enetra.js
@@ -67,7 +67,7 @@ function getPopUps() {
   var popups = {};
   mapDrawElements.forEach((el) => {
     // look inside a possible template first, query map element if no template exits
-    const templateContent = el.querySelector('template.map-content-only').content || el;
+    const templateContent = el.querySelector('template.map-content-only')?.content || el;
     const popup = templateContent.querySelector('.map-popup-content');
     if (!popup) return
     const input = el.querySelector('textarea[name=geom],input[name=geom]');
@@ -83,7 +83,7 @@ function getMarkers() {
   var markers = {};
   mapDrawElements.forEach((el) => {
     // look inside a possible template first, query map element if no template exits
-    const templateContent = el.querySelector('template.map-content-only').content || el;
+    const templateContent = el.querySelector('template.map-content-only')?.content || el;
     const found_markers = templateContent.querySelectorAll('.map-marker');
     if (found_markers.length < 1) return
     const input = el.querySelector('textarea[name=geom],input[name=geom]');

--- a/static/js/map-interface-enetra.js
+++ b/static/js/map-interface-enetra.js
@@ -104,6 +104,8 @@ function getGeoJsons() {
     // const inputs = document.querySelectorAll('.map-draw-element.' + name + '> textarea, .map-draw-element.' + name + ' > input');
     if (inputs.length == 0) {
       console.log(`No inputs found for layer ${name}`)
+    } else {
+      console.log(`Inputs found for ${name}: ${inputs.length}`)
     }
 
     // Add a style to each geometry/Feature, the layer name, and a unique identifier

--- a/templates/cotton/list/item.html
+++ b/templates/cotton/list/item.html
@@ -20,9 +20,16 @@ wrap everyting in a label so everything toggles the radio/checkbox
           if(isSelected)selected=$el.querySelector('input').value
         }
         "
-       @checked="isSelected=true; event.preventDefault(); $dispatch('item-selected',{ value:'{{value}}'} );"
-       @unchecked="isSelected=false; event.preventDefault();$dispatch('item-unselected',{ value:'{{value}}'} );"
-        @map-layer-clicked.window="if (event.detail.value=='{{item.internal_id}}'){$el.click();}"
+        @checked="isSelected=true;
+                  event.preventDefault();
+                  $dispatch('item-selected',{ value:'{{value}}'} );
+                  $dispatch('item-selected-{{value}}',{ value:'{{value}}'} );"
+        @unchecked="isSelected=false;
+        event.preventDefault();
+        $dispatch('item-unselected',{ value:'{{value}}'} );
+        $dispatch('item-unselected-{{value}}',{ value:'{{value}}'} );
+        "
+        @map-layer-{{value}}-clicked.window="$el.click();"
 
 
        {{ attrs }}

--- a/templates/cotton/list/item.html
+++ b/templates/cotton/list/item.html
@@ -29,7 +29,6 @@ wrap everyting in a label so everything toggles the radio/checkbox
         $dispatch('item-unselected',{ value:'{{value}}'} );
         $dispatch('item-unselected-{{value}}',{ value:'{{value}}'} );
         "
-        @map-layer-{{value}}-clicked.window="$el.click();"
 
 
        {{ attrs }}

--- a/templates/cotton/map_element/index.html
+++ b/templates/cotton/map_element/index.html
@@ -7,8 +7,8 @@ Native html element which is used as state for the leaflet map
 <div
     x-data='{selected: false, highlighted: false}'
 
-    @item-unselected.window="if (event.detail.value=='{{key}}'){$dispatch('map-item-stop-highlight', {value:'{{key}}'})}"
-    @item-selected.window="if (event.detail.value=='{{key}}'){ $dispatch('map-item-highlight', {value:'{{key}}'})}"
+    @item-selected-{{key}}.window="$dispatch('map-item-highlight', {value:'{{key}}'})"
+    @item-unselected-{{key}}.window="$dispatch('map-item-stop-highlight', {value:'{{key}}'})"
     @input="$dispatch('geom-changed');"
     x-effect ="
     selected = $store.map.editingElements.has('{{key}}');


### PR DESCRIPTION
Waiting for #38 which introduces performance issues with scenarios with 800+ areas
get_authentification for geometries needs merge with project scoped authorization (ports/views.py 273)
Make the listeners of map-elements and list items more specific. this drastically improves performance for large area sets.
Lazy load geometries. geometries are loaded after page load. this reduces the time of first  possible interaction with the tool

The following steps were realized (required):
- [ ] PEP 8 conform formatting (`ruff`)
- [ ] Check if tests pass locally
- [ ] Add the description of your changes to the CHANGELOG.md in subsection with release name `## [Unreleased]` and state the PR number with `#`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] Write test(s) for new patch of code
